### PR TITLE
Update Makefile to that the paths are now compliant with debian 8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ kernel.syms: kernel.elf
 
 #kernel.elf: LDFLAGS += -L "/opt/Xilinx/14.2/ISE_DS/EDK/gnu/arm/lin64/lib/gcc/arm-xilinx-eabi/4.6.1/" -lgcc
 #kernel.elf: LDFLAGS += -L "/opt/Xilinx/14.2/ISE_DS/EDK/gnu/arm/lin64/arm-xilinx-eabi/lib/" -lc
-kernel.elf: LDFLAGS += -L "/usr/lib/gcc/arm-none-eabi/4.7.4" -lgcc
-kernel.elf: LDFLAGS += -L "/usr/arm-none-eabi/lib" -lc
+kernel.elf: LDFLAGS += -L "/usr/lib/gcc/arm-none-eabi/4.8/" -lgcc
+kernel.elf: LDFLAGS += -L "/usr/lib/arm-none-eabi/lib/" -lc
 kernel.elf: $(OBJECTS)
 	$(Q)$(LD) $(OBJECTS) -Map kernel.map -o $@ -T $(LINKER_SCRIPT) $(LDFLAGS)


### PR DESCRIPTION
I've tried this on 2 different debian, the fixed path seems ok now. It remains distribution dependant, I don't have a better idea to make this clean right now (except parsing gcc output and a bunch of find but we don't want to do that do we?)