### PR TITLE
Interrupts: restructure, handle multiple pending interrupts at once

### DIFF
--- a/Demo/Drivers/interrupts.c
+++ b/Demo/Drivers/interrupts.c
@@ -48,8 +48,9 @@ static void handleRange (unsigned long pending, const unsigned int base)
 		// Map to IRQ number:
 		unsigned int irq = base + bit;
 
-		// Call interrupt handler:
-		g_VectorTable[irq].pfnHandler(irq, g_VectorTable[irq].pParam);
+		// Call interrupt handler, if enabled:
+		if (g_VectorTable[irq].pfnHandler)
+			g_VectorTable[irq].pfnHandler(irq, g_VectorTable[irq].pParam);
 
 		// Clear bit in bitfield:
 		pending &= ~(1UL << bit);
@@ -77,26 +78,6 @@ void irqHandler (void)
 	if (ulMaskedStatus & 0xFF)
 		handleRange(ulMaskedStatus & 0xFF & enabled[2], 64);
 }
-
-static void stubHandler (const unsigned int irq, void *pParam)
-{
-	/**
-	 *	Actually if we get here, we should probably disable the IRQ,
-	 *	otherwise we could lock up this system, as there is nothing to
-	 *	ackknowledge the interrupt.
-	 **/
-}
-
-int InitInterruptController() {
-	int i;
-	for(i = 0; i < BCM2835_INTC_TOTAL_IRQ; i++) {
-		g_VectorTable[i].pfnHandler 	= stubHandler;
-		g_VectorTable[i].pParam			= (void *) 0;
-	}
-	return 0;
-}
-
-
 
 int RegisterInterrupt (const unsigned int irq, FN_INTERRUPT_HANDLER pfnHandler, void *pParam)
 {

--- a/Demo/Drivers/interrupts.h
+++ b/Demo/Drivers/interrupts.h
@@ -8,7 +8,7 @@
 #ifndef _INTERRUPTS_H_
 #define _INTERRUPTS_H_
 
-typedef void (*FN_INTERRUPT_HANDLER)(int nIRQ, void *pParam);
+typedef void (*FN_INTERRUPT_HANDLER) (unsigned int irq, void *pParam);
 
 typedef struct {
 	FN_INTERRUPT_HANDLER 	pfnHandler;			///< Function that handles this IRQn
@@ -16,10 +16,10 @@ typedef struct {
 } INTERRUPT_VECTOR;
 
 int InitInterruptController	();
-int RegisterInterrupt		(int nIRQ, FN_INTERRUPT_HANDLER pfnHandler, void *pParam);
-int EnableInterrupt			(int nIRQ);
-int DisableInterrupt		(int nIRQ);
-int EnableInterrupts		();
-int DisableInterrupts		();
+int RegisterInterrupt		(const unsigned int irq, FN_INTERRUPT_HANDLER pfnHandler, void *pParam);
+int EnableInterrupt			(const unsigned int irq);
+int DisableInterrupt		(const unsigned int irq);
+int EnableInterrupts		(void);
+int DisableInterrupts		(void);
 
 #endif

--- a/Demo/Drivers/interrupts.h
+++ b/Demo/Drivers/interrupts.h
@@ -15,10 +15,10 @@ typedef struct {
 	void 				   *pParam;				///< A special parameter that the use can pass to the IRQ.
 } INTERRUPT_VECTOR;
 
-int RegisterInterrupt		(const unsigned int irq, FN_INTERRUPT_HANDLER pfnHandler, void *pParam);
-int EnableInterrupt			(const unsigned int irq);
-int DisableInterrupt		(const unsigned int irq);
-int EnableInterrupts		(void);
-int DisableInterrupts		(void);
+void RegisterInterrupt		(const unsigned int irq, FN_INTERRUPT_HANDLER pfnHandler, void *pParam);
+void EnableInterrupt		(const unsigned int irq);
+void DisableInterrupt		(const unsigned int irq);
+void EnableInterrupts		(void);
+void DisableInterrupts		(void);
 
 #endif

--- a/Demo/Drivers/interrupts.h
+++ b/Demo/Drivers/interrupts.h
@@ -15,7 +15,6 @@ typedef struct {
 	void 				   *pParam;				///< A special parameter that the use can pass to the IRQ.
 } INTERRUPT_VECTOR;
 
-int InitInterruptController	();
 int RegisterInterrupt		(const unsigned int irq, FN_INTERRUPT_HANDLER pfnHandler, void *pParam);
 int EnableInterrupt			(const unsigned int irq);
 int DisableInterrupt		(const unsigned int irq);

--- a/Demo/Drivers/irq.c
+++ b/Demo/Drivers/irq.c
@@ -3,7 +3,7 @@
  *	@author	James Walmsley <james@fullfat-fs.co.uk>
  **/
 
-#include "interrupts.h"
+#include "irq.h"
 #include "bcm2835_intc.h"
 
 static INTERRUPT_VECTOR g_VectorTable[BCM2835_INTC_TOTAL_IRQ];
@@ -68,27 +68,27 @@ void irqHandler (void)
 		handleRange(ulMaskedStatus & 0xFF & enabled[2], 64);
 }
 
-void EnableInterrupts (void)
+void irqUnblock (void)
 {
 	asm volatile ("cpsie i" ::: "memory");
 }
 
-void DisableInterrupts (void)
+void irqBlock (void)
 {
 	asm volatile ("cpsid i" ::: "memory");
 }
 
-void RegisterInterrupt (const unsigned int irq, FN_INTERRUPT_HANDLER pfnHandler, void *pParam)
+void irqRegister (const unsigned int irq, FN_INTERRUPT_HANDLER pfnHandler, void *pParam)
 {
 	if (irq < BCM2835_INTC_TOTAL_IRQ) {
-		DisableInterrupts();
+		irqBlock();
 		g_VectorTable[irq].pfnHandler = pfnHandler;
 		g_VectorTable[irq].pParam     = pParam;
-		EnableInterrupts();
+		irqUnblock();
 	}
 }
 
-void EnableInterrupt (const unsigned int irq)
+void irqEnable (const unsigned int irq)
 {
 	unsigned long mask = 1UL << (irq % 32);
 
@@ -106,7 +106,7 @@ void EnableInterrupt (const unsigned int irq)
 	}
 }
 
-void DisableInterrupt (const unsigned int irq)
+void irqDisable (const unsigned int irq)
 {
 	unsigned long mask = 1UL << (irq % 32);
 

--- a/Demo/Drivers/irq.h
+++ b/Demo/Drivers/irq.h
@@ -15,10 +15,10 @@ typedef struct {
 	void 				   *pParam;				///< A special parameter that the use can pass to the IRQ.
 } INTERRUPT_VECTOR;
 
-void RegisterInterrupt		(const unsigned int irq, FN_INTERRUPT_HANDLER pfnHandler, void *pParam);
-void EnableInterrupt		(const unsigned int irq);
-void DisableInterrupt		(const unsigned int irq);
-void EnableInterrupts		(void);
-void DisableInterrupts		(void);
+void irqRegister	(const unsigned int irq, FN_INTERRUPT_HANDLER pfnHandler, void *pParam);
+void irqEnable		(const unsigned int irq);
+void irqDisable		(const unsigned int irq);
+void irqBlock		(void);
+void irqUnblock		(void);
 
 #endif

--- a/Demo/main.c
+++ b/Demo/main.c
@@ -32,11 +32,8 @@ void task2(void *pParam) {
  *	-- Absolutely nothing wrong with this being called main(), just it doesn't have
  *	-- the same prototype as you'd see in a linux program.
  **/
-void main(void) {
-
-	DisableInterrupts();
-	InitInterruptController();
-
+void main (void)
+{
 	SetGpioFunction(16, 1);			// RDY led
 
 	xTaskCreate(task1, "LED_0", 128, NULL, 0, NULL);

--- a/Demo/main.c
+++ b/Demo/main.c
@@ -1,7 +1,7 @@
 #include <FreeRTOS.h>
 #include <task.h>
 
-#include "Drivers/interrupts.h"
+#include "Drivers/irq.h"
 #include "Drivers/gpio.h"
 
 void task1(void *pParam) {

--- a/Demo/startup.s
+++ b/Demo/startup.s
@@ -3,7 +3,7 @@
 .extern __bss_end
 .extern vFreeRTOS_ISR
 .extern vPortYieldProcessor
-.extern DisableInterrupts
+.extern irqBlock
 .extern main
 	.section .init
 	.globl _start
@@ -75,7 +75,7 @@ zero_loop:
 	strlt	r2,[r0], #4
 	blt		zero_loop
 
-	bl 		DisableInterrupts
+	bl 		irqBlock
 	
 	
 	;@ 	mov	sp,#0x1000000

--- a/FreeRTOS/Source/portable/GCC/RaspberryPi/port.c
+++ b/FreeRTOS/Source/portable/GCC/RaspberryPi/port.c
@@ -153,7 +153,7 @@ void vPortEndScheduler( void )
  *
  *	See bt_interrupts.c in the RaspberryPi Drivers folder.
  */
-void vTickISR(int nIRQ, void *pParam )
+void vTickISR (unsigned int nIRQ, void *pParam)
 {
 	vTaskIncrementTick();
 

--- a/FreeRTOS/Source/portable/GCC/RaspberryPi/port.c
+++ b/FreeRTOS/Source/portable/GCC/RaspberryPi/port.c
@@ -4,7 +4,7 @@
 
 #include "FreeRTOS.h"
 #include "task.h"
-#include <Drivers/interrupts.h>
+#include <Drivers/irq.h>
 
 /* Constants required to setup the task context. */
 #define portINITIAL_SPSR						( ( portSTACK_TYPE ) 0x1f ) /* System mode, ARM mode, interrupts enabled. */
@@ -183,7 +183,7 @@ static void prvSetupTimerInterrupt( void )
 	}
 	#endif
 
-	DisableInterrupts();
+	irqBlock();
 
 	pRegs->CTL = 0x003E0000;
 	pRegs->LOD = 1000 - 1;
@@ -192,11 +192,11 @@ static void prvSetupTimerInterrupt( void )
 	pRegs->CLI = 0;
 	pRegs->CTL = 0x003E00A2;
 
-	RegisterInterrupt(64, vTickISR, NULL);
+	irqRegister(64, vTickISR, NULL);
 
-	EnableInterrupt(64);
+	irqEnable(64);
 
-	EnableInterrupts();
+	irqUnblock();
 }
 /*-----------------------------------------------------------*/
 

--- a/objects.mk
+++ b/objects.mk
@@ -15,7 +15,7 @@ OBJECTS += $(BUILD_DIR)FreeRTOS/Source/tasks.o
 #
 #	Interrupt Manager & GPIO Drivers
 #
-OBJECTS += $(BUILD_DIR)Demo/Drivers/interrupts.o
+OBJECTS += $(BUILD_DIR)Demo/Drivers/irq.o
 OBJECTS += $(BUILD_DIR)Demo/Drivers/gpio.o
 
 $(BUILD_DIR)FreeRTOS/Source/portable/GCC/RaspberryPi/port.o: CFLAGS += -I $(BASE)Demo/


### PR DESCRIPTION
- Handle all pending interrupts inside the interrupt handler instead of just one;
- Remember which interrupts have been enabled and only handle those;
- Rename `interrupts.*` to `irq.*` for brevity;
- Namespace functions as `irqSomething()` for uniformity;
- Use natural `unsigned int` for IRQ numbers;
- Return `void` when function cannot fail.