### PR TITLE
GPIO functions: rewrite, add functionality

### DIFF
--- a/Demo/Drivers/gpio.c
+++ b/Demo/Drivers/gpio.c
@@ -110,11 +110,19 @@ gpioDetectDisable (const unsigned int pin, const enum GpioDetect type)
 	detect_map[type][bank] &= ~mask;
 }
 
-void
-gpioInterruptClear (const unsigned int pin)
+unsigned int
+gpioDetected (const unsigned int pin)
 {
 	unsigned long bank = BANK(pin);
 	unsigned long mask = MASK(pin);
 
-	GPEDS[bank] = mask;
+	// No event if bit not set:
+	if (!(GPEDS[bank] & mask))
+		return 0;
+
+	// Clear event by setting bit to 1:
+	GPEDS[bank] |= mask;
+
+	// Confirm event:
+	return 1;
 }

--- a/Demo/Drivers/gpio.c
+++ b/Demo/Drivers/gpio.c
@@ -38,47 +38,49 @@ typedef struct {
 
 volatile BCM2835_GPIO_REGS * const pRegs = (BCM2835_GPIO_REGS *) (0x20200000);
 
-
-void SetGpioFunction(unsigned int pinNum, unsigned int funcNum) {
-
-	int offset = pinNum / 10;
+void
+gpioFunctionSet (const unsigned int pin, const unsigned int func)
+{
+	int offset = pin / 10;
 
 	unsigned long val = pRegs->GPFSEL[offset];	// Read in the original register value.
 
-	int item = pinNum % 10;
+	int item = pin % 10;
 	val &= ~(0x7 << (item * 3));
-	val |= ((funcNum & 0x7) << (item * 3));
+	val |= ((func & 0x7) << (item * 3));
 	pRegs->GPFSEL[offset] = val;
 }
 
-void SetGpioDirection(unsigned int pinNum, enum GPIO_DIR dir) {
-	SetGpioFunction(pinNum,dir);
+void
+gpioDirectionSet (const unsigned int pin, const enum GPIO_DIR dir)
+{
+	gpioFunctionSet(pin, dir);
 }
 
-void SetGpio(unsigned int pinNum, unsigned int pinVal)
+void
+gpioWrite (const unsigned int pin, const unsigned int val)
 {
-	unsigned long bank = BANK(pinNum);
-	unsigned long mask = MASK(pinNum);
+	unsigned long bank = BANK(pin);
+	unsigned long mask = MASK(pin);
 
-	if(pinVal) {
-		pRegs->GPSET[bank] |= mask;
-	} else {
-		pRegs->GPCLR[bank] |= mask;
-	}
+	val ? (pRegs->GPSET[bank] |= mask)
+	    : (pRegs->GPCLR[bank] |= mask);
 }
 
-int ReadGpio(unsigned int pinNum)
+unsigned int
+gpioRead (const unsigned int pin)
 {
-	unsigned long bank = BANK(pinNum);
-	unsigned long mask = MASK(pinNum);
+	unsigned long bank = BANK(pin);
+	unsigned long mask = MASK(pin);
 
 	return ((pRegs->GPLEV[bank]) >> mask) & 1;
 }
 
-void EnableGpioDetect(unsigned int pinNum, enum DETECT_TYPE type)
+void
+gpioDetectEnable (const unsigned int pin, const enum DETECT_TYPE type)
 {
-	unsigned long bank = BANK(pinNum);
-	unsigned long mask = MASK(pinNum);
+	unsigned long bank = BANK(pin);
+	unsigned long mask = MASK(pin);
 
 	switch(type) {
 	case DETECT_RISING:
@@ -104,10 +106,11 @@ void EnableGpioDetect(unsigned int pinNum, enum DETECT_TYPE type)
 	}
 }
 
-void DisableGpioDetect(unsigned int pinNum, enum DETECT_TYPE type)
+void
+gpioDetectDisable (const unsigned int pin, const enum DETECT_TYPE type)
 {
-	unsigned long bank = BANK(pinNum);
-	unsigned long mask = MASK(pinNum);
+	unsigned long bank = BANK(pin);
+	unsigned long mask = MASK(pin);
 
 	switch(type) {
 	case DETECT_RISING:
@@ -133,10 +136,11 @@ void DisableGpioDetect(unsigned int pinNum, enum DETECT_TYPE type)
 	}
 }
 
-void ClearGpioInterrupt(unsigned int pinNum)
+void
+gpioInterruptClear (const unsigned int pin)
 {
-	unsigned long bank = BANK(pinNum);
-	unsigned long mask = MASK(pinNum);
+	unsigned long bank = BANK(pin);
+	unsigned long mask = MASK(pin);
 
 	pRegs->GPEDS[bank] = mask;
 }

--- a/Demo/Drivers/gpio.c
+++ b/Demo/Drivers/gpio.c
@@ -36,23 +36,32 @@
 #define GPAFEN		GPIO_REG (0x0088)
 
 void
-gpioFunctionSet (const unsigned int pin, const unsigned int func)
+gpioFunctionSet (const unsigned int pin, const enum GpioFunc func)
 {
-	int offset = pin / 10;
+	unsigned long bank = pin / 10;
+	unsigned long item = pin % 10;
+	unsigned long mask = 7UL << (item * 3);
 
-	// Read in the original register value:
-	unsigned long val = GPFSEL[offset];
+	// Get current register value:
+	unsigned long reg = GPFSEL[bank];
 
-	int item = pin % 10;
-	val &= ~(0x7 << (item * 3));
-	val |= ((func & 0x7) << (item * 3));
-	GPFSEL[offset] = val;
+	// Mask out the bits for this pin:
+	reg &= ~mask;
+
+	// Insert new bits for this pin:
+	reg |= (unsigned long)func << (item * 3);
+
+	// Store back:
+	GPFSEL[bank] = reg;
 }
 
-void
-gpioDirectionSet (const unsigned int pin, const enum GpioDir dir)
+enum GpioFunc
+gpioFunctionGet (const unsigned int pin)
 {
-	gpioFunctionSet(pin, dir);
+	unsigned long bank = pin / 10;
+	unsigned long item = pin % 10;
+
+	return (GPFSEL[bank] >> (item * 3)) & 7;
 }
 
 void

--- a/Demo/Drivers/gpio.c
+++ b/Demo/Drivers/gpio.c
@@ -8,35 +8,35 @@
 #define BANK(pin)	((pin) >> 5)
 #define MASK(pin)	(1UL << ((pin) & 0x1F))
 
-typedef struct {
-	unsigned long	GPFSEL[6];	///< Function selection registers.
-	unsigned long	Reserved_1;
-	unsigned long	GPSET[2];
-	unsigned long	Reserved_2;
-	unsigned long	GPCLR[2];
-	unsigned long	Reserved_3;
-	unsigned long	GPLEV[2];
-	unsigned long	Reserved_4;
-	unsigned long	GPEDS[2];
-	unsigned long	Reserved_5;
-	unsigned long	GPREN[2];
-	unsigned long	Reserved_6;
-	unsigned long	GPFEN[2];
-	unsigned long	Reserved_7;
-	unsigned long	GPHEN[2];
-	unsigned long	Reserved_8;
-	unsigned long	GPLEN[2];
-	unsigned long	Reserved_9;
-	unsigned long	GPAREN[2];
-	unsigned long	Reserved_A;
-	unsigned long	GPAFEN[2];
-	unsigned long	Reserved_B;
-	unsigned long	GPPUD[1];
-	unsigned long	GPPUDCLK[2];
-	//Ignoring the reserved and test bytes
-} BCM2835_GPIO_REGS;
+// Base memory location for GPIO registers:
+#define GPIO_REG_BASE	0x20200000
 
-volatile BCM2835_GPIO_REGS * const pRegs = (BCM2835_GPIO_REGS *) (0x20200000);
+// Define a GPIO register:
+#define GPIO_REG(offs)	((volatile unsigned long *) (GPIO_REG_BASE + offs))
+
+// Pin event detection:
+#define GPREN		GPIO_REG (0x004C)
+#define GPFEN		GPIO_REG (0x0058)
+#define GPHEN		GPIO_REG (0x0064)
+#define GPLEN		GPIO_REG (0x0070)
+#define GPAREN		GPIO_REG (0x007C)
+#define GPAFEN		GPIO_REG (0x0088)
+
+typedef struct {
+	unsigned long GPFSEL[6];	///< Function selection registers.
+	unsigned long Reserved_1;
+	unsigned long GPSET[2];
+	unsigned long Reserved_2;
+	unsigned long GPCLR[2];
+	unsigned long Reserved_3;
+	unsigned long GPLEV[2];
+	unsigned long Reserved_4;
+	unsigned long GPEDS[2];
+	unsigned long Reserved_5;
+} __attribute__((packed))
+BCM2835_GPIO_REGS;
+
+volatile BCM2835_GPIO_REGS * const pRegs = (BCM2835_GPIO_REGS *) (GPIO_REG_BASE);
 
 void
 gpioFunctionSet (const unsigned int pin, const unsigned int func)
@@ -76,35 +76,22 @@ gpioRead (const unsigned int pin)
 	return ((pRegs->GPLEV[bank]) >> mask) & 1;
 }
 
+static volatile unsigned long *detect_map[] = {
+	[GPIO_DETECT_RISING]        = GPREN,
+	[GPIO_DETECT_FALLING]       = GPFEN,
+	[GPIO_DETECT_HIGH]          = GPHEN,
+	[GPIO_DETECT_LOW]           = GPLEN,
+	[GPIO_DETECT_RISING_ASYNC]  = GPAREN,
+	[GPIO_DETECT_FALLING_ASYNC] = GPAFEN,
+};
+
 void
 gpioDetectEnable (const unsigned int pin, const enum GpioDetect type)
 {
 	unsigned long bank = BANK(pin);
 	unsigned long mask = MASK(pin);
 
-	switch (type)
-	{
-	case GPIO_DETECT_RISING:
-		pRegs->GPREN[bank] |= mask;
-		break;
-	case GPIO_DETECT_FALLING:
-		pRegs->GPFEN[bank] |= mask;
-		break;
-	case GPIO_DETECT_HIGH:
-		pRegs->GPHEN[bank] |= mask;
-		break;
-	case GPIO_DETECT_LOW:
-		pRegs->GPLEN[bank] |= mask;
-		break;
-	case GPIO_DETECT_RISING_ASYNC:
-		pRegs->GPAREN[bank] |= mask;
-		break;
-	case GPIO_DETECT_FALLING_ASYNC:
-		pRegs->GPAFEN[bank] |= mask;
-		break;
-	case GPIO_DETECT_NONE:
-		break;
-	}
+	detect_map[type][bank] |= mask;
 }
 
 void
@@ -113,29 +100,7 @@ gpioDetectDisable (const unsigned int pin, const enum GpioDetect type)
 	unsigned long bank = BANK(pin);
 	unsigned long mask = MASK(pin);
 
-	switch (type)
-	{
-	case GPIO_DETECT_RISING:
-		pRegs->GPREN[bank] &= ~mask;
-		break;
-	case GPIO_DETECT_FALLING:
-		pRegs->GPFEN[bank] &= ~mask;
-		break;
-	case GPIO_DETECT_HIGH:
-		pRegs->GPHEN[bank] &= ~mask;
-		break;
-	case GPIO_DETECT_LOW:
-		pRegs->GPLEN[bank] &= ~mask;
-		break;
-	case GPIO_DETECT_RISING_ASYNC:
-		pRegs->GPAREN[bank] &= ~mask;
-		break;
-	case GPIO_DETECT_FALLING_ASYNC:
-		pRegs->GPAFEN[bank] &= ~mask;
-		break;
-	case GPIO_DETECT_NONE:
-		break;
-	}
+	detect_map[type][bank] &= ~mask;
 }
 
 void

--- a/Demo/Drivers/gpio.c
+++ b/Demo/Drivers/gpio.c
@@ -52,7 +52,7 @@ gpioFunctionSet (const unsigned int pin, const unsigned int func)
 }
 
 void
-gpioDirectionSet (const unsigned int pin, const enum GPIO_DIR dir)
+gpioDirectionSet (const unsigned int pin, const enum GpioDir dir)
 {
 	gpioFunctionSet(pin, dir);
 }
@@ -77,61 +77,63 @@ gpioRead (const unsigned int pin)
 }
 
 void
-gpioDetectEnable (const unsigned int pin, const enum DETECT_TYPE type)
+gpioDetectEnable (const unsigned int pin, const enum GpioDetect type)
 {
 	unsigned long bank = BANK(pin);
 	unsigned long mask = MASK(pin);
 
-	switch(type) {
-	case DETECT_RISING:
+	switch (type)
+	{
+	case GPIO_DETECT_RISING:
 		pRegs->GPREN[bank] |= mask;
 		break;
-	case DETECT_FALLING:
+	case GPIO_DETECT_FALLING:
 		pRegs->GPFEN[bank] |= mask;
 		break;
-	case DETECT_HIGH:
+	case GPIO_DETECT_HIGH:
 		pRegs->GPHEN[bank] |= mask;
 		break;
-	case DETECT_LOW:
+	case GPIO_DETECT_LOW:
 		pRegs->GPLEN[bank] |= mask;
 		break;
-	case DETECT_RISING_ASYNC:
+	case GPIO_DETECT_RISING_ASYNC:
 		pRegs->GPAREN[bank] |= mask;
 		break;
-	case DETECT_FALLING_ASYNC:
+	case GPIO_DETECT_FALLING_ASYNC:
 		pRegs->GPAFEN[bank] |= mask;
 		break;
-	case DETECT_NONE:
+	case GPIO_DETECT_NONE:
 		break;
 	}
 }
 
 void
-gpioDetectDisable (const unsigned int pin, const enum DETECT_TYPE type)
+gpioDetectDisable (const unsigned int pin, const enum GpioDetect type)
 {
 	unsigned long bank = BANK(pin);
 	unsigned long mask = MASK(pin);
 
-	switch(type) {
-	case DETECT_RISING:
+	switch (type)
+	{
+	case GPIO_DETECT_RISING:
 		pRegs->GPREN[bank] &= ~mask;
 		break;
-	case DETECT_FALLING:
+	case GPIO_DETECT_FALLING:
 		pRegs->GPFEN[bank] &= ~mask;
 		break;
-	case DETECT_HIGH:
+	case GPIO_DETECT_HIGH:
 		pRegs->GPHEN[bank] &= ~mask;
 		break;
-	case DETECT_LOW:
+	case GPIO_DETECT_LOW:
 		pRegs->GPLEN[bank] &= ~mask;
 		break;
-	case DETECT_RISING_ASYNC:
+	case GPIO_DETECT_RISING_ASYNC:
 		pRegs->GPAREN[bank] &= ~mask;
 		break;
-	case DETECT_FALLING_ASYNC:
+	case GPIO_DETECT_FALLING_ASYNC:
 		pRegs->GPAFEN[bank] &= ~mask;
 		break;
-	case DETECT_NONE:
+	case GPIO_DETECT_NONE:
 		break;
 	}
 }

--- a/Demo/Drivers/gpio.h
+++ b/Demo/Drivers/gpio.h
@@ -3,7 +3,6 @@
 
 // GPIO event detect types
 enum GpioDetect {
-	GPIO_DETECT_NONE,
 	GPIO_DETECT_RISING,
 	GPIO_DETECT_FALLING,
 	GPIO_DETECT_HIGH,

--- a/Demo/Drivers/gpio.h
+++ b/Demo/Drivers/gpio.h
@@ -1,36 +1,36 @@
 #ifndef _GPIO_H_
 #define _GPIO_H_
 
-/* GPIO event detect types */
-enum DETECT_TYPE {
-	DETECT_NONE,
-	DETECT_RISING,
-	DETECT_FALLING,
-	DETECT_HIGH,
-	DETECT_LOW,
-	DETECT_RISING_ASYNC,
-	DETECT_FALLING_ASYNC
+// GPIO event detect types
+enum GpioDetect {
+	GPIO_DETECT_NONE,
+	GPIO_DETECT_RISING,
+	GPIO_DETECT_FALLING,
+	GPIO_DETECT_HIGH,
+	GPIO_DETECT_LOW,
+	GPIO_DETECT_RISING_ASYNC,
+	GPIO_DETECT_FALLING_ASYNC,
 };
 
-/* GPIO pull up or down states */
-enum PULL_STATE {
-	PULL_DISABLE,
-	PULL_UP,
-	PULL_DOWN,
-	PULL_RESERVED
+// GPIO pull up or down states
+enum GpioPull {
+	GPIO_PULL_DISABLE,
+	GPIO_PULL_UP,
+	GPIO_PULL_DOWN,
+	GPIO_PULL_RESERVED,
 };
 
-/* Pin data direction */
-enum GPIO_DIR {
-	GPIO_IN,
-	GPIO_OUT
+// Pin data direction
+enum GpioDir {
+	GPIO_DIR_IN,
+	GPIO_DIR_OUT,
 };
 
 // GPIO pin setup:
 void gpioFunctionSet (const unsigned int pin, const unsigned int func);
 
 // A simple wrapper around SetGpioFunction:
-void gpioDirectionSet (const unsigned int pin, const enum GPIO_DIR dir);
+void gpioDirectionSet (const unsigned int pin, const enum GpioDir dir);
 
 // Set GPIO output level:
 void gpioWrite (const unsigned int pin, const unsigned int val);
@@ -39,11 +39,11 @@ void gpioWrite (const unsigned int pin, const unsigned int val);
 unsigned int gpioRead (const unsigned int pin);
 
 // GPIO pull up/down resistor control function (NOT YET IMPLEMENTED):
-int gpioPud (const unsigned int pin, const enum PULL_STATE state);
+int gpioPud (const unsigned int pin, const enum GpioPull state);
 
 // Interrupt related functions:
-void gpioDetectEnable   (const unsigned int pin, const enum DETECT_TYPE type);
-void gpioDetectDisable  (const unsigned int pin, const enum DETECT_TYPE type);
+void gpioDetectEnable   (const unsigned int pin, const enum GpioDetect type);
+void gpioDetectDisable  (const unsigned int pin, const enum GpioDetect type);
 void gpioInterruptClear (const unsigned int pin);
 
 #endif

--- a/Demo/Drivers/gpio.h
+++ b/Demo/Drivers/gpio.h
@@ -13,10 +13,10 @@ enum GpioDetect {
 
 // GPIO pull up or down states
 enum GpioPull {
-	GPIO_PULL_DISABLE,
-	GPIO_PULL_UP,
-	GPIO_PULL_DOWN,
-	GPIO_PULL_RESERVED,
+	GPIO_PULL_DISABLE	= 0,
+	GPIO_PULL_DOWN		= 1,
+	GPIO_PULL_UP		= 2,
+	GPIO_PULL_RESERVED	= 3,
 };
 
 // Pin functions
@@ -43,8 +43,8 @@ void gpioWrite (const unsigned int pin, const unsigned int val);
 // Read GPIO pin level:
 unsigned int gpioRead (const unsigned int pin);
 
-// GPIO pull up/down resistor control function (NOT YET IMPLEMENTED):
-int gpioPud (const unsigned int pin, const enum GpioPull state);
+// GPIO pull-up/down/none:
+void gpioPull (const unsigned int pin, const enum GpioPull type);
 
 // Event detection functions:
 void gpioDetectEnable     (const unsigned int pin, const enum GpioDetect type);

--- a/Demo/Drivers/gpio.h
+++ b/Demo/Drivers/gpio.h
@@ -46,9 +46,9 @@ unsigned int gpioRead (const unsigned int pin);
 // GPIO pull up/down resistor control function (NOT YET IMPLEMENTED):
 int gpioPud (const unsigned int pin, const enum GpioPull state);
 
-// Interrupt related functions:
-void gpioDetectEnable   (const unsigned int pin, const enum GpioDetect type);
-void gpioDetectDisable  (const unsigned int pin, const enum GpioDetect type);
-void gpioInterruptClear (const unsigned int pin);
+// Event detection functions:
+void gpioDetectEnable     (const unsigned int pin, const enum GpioDetect type);
+void gpioDetectDisable    (const unsigned int pin, const enum GpioDetect type);
+unsigned int gpioDetected (const unsigned int pin);
 
 #endif

--- a/Demo/Drivers/gpio.h
+++ b/Demo/Drivers/gpio.h
@@ -19,17 +19,23 @@ enum GpioPull {
 	GPIO_PULL_RESERVED,
 };
 
-// Pin data direction
-enum GpioDir {
-	GPIO_DIR_IN,
-	GPIO_DIR_OUT,
+// Pin functions
+enum GpioFunc {
+	GPIO_FUNC_INPUT		= 0,	// Pin is input
+	GPIO_FUNC_OUTPUT	= 1,	// Pin is output
+	GPIO_FUNC_ALT_0		= 4,	// Alternative function 0
+	GPIO_FUNC_ALT_1		= 5,	// Alternative function 1
+	GPIO_FUNC_ALT_2		= 6,	// Alternative function 2
+	GPIO_FUNC_ALT_3		= 7,	// Alternative function 3
+	GPIO_FUNC_ALT_4		= 3,	// Alternative function 4
+	GPIO_FUNC_ALT_5		= 2,	// Alternative function 5
 };
 
-// GPIO pin setup:
-void gpioFunctionSet (const unsigned int pin, const unsigned int func);
+// Set GPIO pin function:
+void gpioFunctionSet (const unsigned int pin, const enum GpioFunc func);
 
-// A simple wrapper around SetGpioFunction:
-void gpioDirectionSet (const unsigned int pin, const enum GpioDir dir);
+// Get GPIO pin function:
+enum GpioFunc gpioFunctionGet (const unsigned int pin);
 
 // Set GPIO output level:
 void gpioWrite (const unsigned int pin, const unsigned int val);

--- a/Demo/Drivers/gpio.h
+++ b/Demo/Drivers/gpio.h
@@ -26,23 +26,24 @@ enum GPIO_DIR {
 	GPIO_OUT
 };
 
-/* GPIO pin setup */
-void SetGpioFunction	(unsigned int pinNum, unsigned int funcNum);
-/* A simple wrapper around SetGpioFunction */
-void SetGpioDirection	(unsigned int pinNum, enum GPIO_DIR dir);
+// GPIO pin setup:
+void gpioFunctionSet (const unsigned int pin, const unsigned int func);
 
-/* Set GPIO output level */
-void SetGpio			(unsigned int pinNum, unsigned int pinVal);
+// A simple wrapper around SetGpioFunction:
+void gpioDirectionSet (const unsigned int pin, const enum GPIO_DIR dir);
 
-/* Read GPIO pin level */
-int ReadGpio			(unsigned int pinNum);
+// Set GPIO output level:
+void gpioWrite (const unsigned int pin, const unsigned int val);
 
-/* GPIO pull up/down resistor control function (NOT YET IMPLEMENTED) */
-int PudGpio				(unsigned int pinNum, enum PULL_STATE state);
+// Read GPIO pin level:
+unsigned int gpioRead (const unsigned int pin);
 
-/* Interrupt related functions */
-void EnableGpioDetect	(unsigned int pinNum, enum DETECT_TYPE type);
-void DisableGpioDetect	(unsigned int pinNum, enum DETECT_TYPE type);
-void ClearGpioInterrupt	(unsigned int pinNum);
+// GPIO pull up/down resistor control function (NOT YET IMPLEMENTED):
+int gpioPud (const unsigned int pin, const enum PULL_STATE state);
+
+// Interrupt related functions:
+void gpioDetectEnable   (const unsigned int pin, const enum DETECT_TYPE type);
+void gpioDetectDisable  (const unsigned int pin, const enum DETECT_TYPE type);
+void gpioInterruptClear (const unsigned int pin);
 
 #endif

--- a/Demo/main.c
+++ b/Demo/main.c
@@ -34,7 +34,7 @@ void task2(void *pParam) {
  **/
 void main (void)
 {
-	gpioFunctionSet(16, 1);			// RDY led
+	gpioFunctionSet(16, GPIO_FUNC_OUTPUT);		// RDY led
 
 	xTaskCreate(task1, "LED_0", 128, NULL, 0, NULL);
 	xTaskCreate(task2, "LED_1", 128, NULL, 0, NULL);

--- a/Demo/main.c
+++ b/Demo/main.c
@@ -9,7 +9,7 @@ void task1(void *pParam) {
 	int i = 0;
 	while(1) {
 		i++;
-		SetGpio(16, 1);
+		gpioWrite(16, 1);
 		vTaskDelay(200);
 	}
 }
@@ -20,7 +20,7 @@ void task2(void *pParam) {
 	while(1) {
 		i++;
 		vTaskDelay(100);
-		SetGpio(16, 0);
+		gpioWrite(16, 0);
 		vTaskDelay(100);
 	}
 }
@@ -34,7 +34,7 @@ void task2(void *pParam) {
  **/
 void main (void)
 {
-	SetGpioFunction(16, 1);			// RDY led
+	gpioFunctionSet(16, 1);			// RDY led
 
 	xTaskCreate(task1, "LED_0", 128, NULL, 0, NULL);
 	xTaskCreate(task2, "LED_1", 128, NULL, 0, NULL);


### PR DESCRIPTION
 - Uniform naming. Functions are called `gpioSomething()`, enums are `GpioSomething`.
 - Decreased size of code, removed some verbose constructs.
 - Added functionality:
   - can set pull up/pull down state (this was left unimplemented in the current code);
   - can read out the event detection state.